### PR TITLE
Display Custom Data

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This firmware uses the WiFi support that your clock already has to sync the time
 * It has a screen saver.
 * There is also a tool to convert images in to a format that can be displayed on the clock
 * It can connect to a MQTT broker, primarily to allow use of movement and luminance sensors. The full state of the clock is published too.
-* The displayed number can be overwritten via MQTT, e.g. to implement automated counters (Custom format: numbers 0-9, ':', ' ' and '_' can be used in a custom string)
+* The displayed number can be overwritten via MQTT, e.g. to implement automated counters (Custom format: numbers 0-9, ':', ' ' and '_' can be used in a custom string; send 'clear' or empty string to stop displaying custom data)
 * There are specific variants for:
   * The [EleksTube v1 clock](https://www.nixies.us/projects/elekstubeips-clock/elekstube-ips-v1/)
   * The [Si Hai](https://www.nixies.us/projects/elekstubeips-clock/elekstube-ips-v1-3/) clock

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # A Custom Firmware for the EleksTube IPS V1 clock
 
-# Features of This Firmware
+## Features of This Firmware
 
 This firmware uses the WiFi support that your clock already has to sync the time with the internet and to provide an easy way to configure the clock and change the display:
 
@@ -23,6 +23,7 @@ This firmware uses the WiFi support that your clock already has to sync the time
 * It has a screen saver.
 * There is also a tool to convert images in to a format that can be displayed on the clock
 * It can connect to a MQTT broker, primarily to allow use of movement and luminance sensors. The full state of the clock is published too.
+* The displayed number can be overwritten via MQTT, e.g. to implement automated counters (Custom format: numbers 0-9, ':', ' ' and '_' can be used in a custom string)
 * There are specific variants for:
   * The [EleksTube v1 clock](https://www.nixies.us/projects/elekstubeips-clock/elekstube-ips-v1/)
   * The [Si Hai](https://www.nixies.us/projects/elekstubeips-clock/elekstube-ips-v1-3/) clock
@@ -42,7 +43,7 @@ This shows the digital rain screen saver:
 
 ![Captive Portal](docs/matrix.jpg)
 
-# Documentation
+## Documentation
 
 See [the wiki](https://github.com/judge2005/EleksTubeIPS/wiki "wiki") for detailed information on how to build, install and use this firmware.
 
@@ -52,7 +53,7 @@ See [the wiki](https://github.com/judge2005/EleksTubeIPS/wiki "wiki") for detail
 * [Image Collections](https://github.com/judge2005/EleksTubeIPS/wiki/Image-Collections) tells you how to prepare new clock faces and weather icon sets so that they can be uploaded to the clock and used.
 * [Hardware Modification](https://github.com/judge2005/EleksTubeIPS/wiki/Hardware-Modification) details a mod that you might want to make to your clock, but only if you are comfortable wielding a soldering iron.
 
-# Credits
+## Credits
 
 [Original documentation and software from EleksMaker.](https://wiki.eleksmaker.com/doku.php?id=ips)
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -42,13 +42,13 @@ lib_deps =
 	TimeSync = https://github.com/judge2005/TimeSync.git#1.1.4
 	ESPConfig = https://github.com/judge2005/ESPConfig.git#1.0.0
 	marvinroger/AsyncMqttClient@0.9.0
-	AsyncTCP=https://git@github.com/judge2005/AsyncTCP.git
-	ESP Async WebServer=https://git@github.com/judge2005/ESPAsyncWebServer.git
+	AsyncTCP=https://github.com/judge2005/AsyncTCP.git
+	ESP Async WebServer=https://github.com/judge2005/ESPAsyncWebServer.git
 	bblanchon/ArduinoJson@7.0.3
 	makuna/NeoPixelBus@2.7.7
 	bodmer/TFT_eSPI@2.5.43
 	tobozo/ESP32-targz@1.2.0
-	eSPI_Menu=git+ssh://git@github.com/judge2005/eSPI_Menu.git
+	eSPI_Menu=https://github.com/judge2005/eSPI_Menu.git
 extra_scripts = 
 	.custom_targets.py
     .merge_firmware.py

--- a/src/IPSClock.cpp
+++ b/src/IPSClock.cpp
@@ -65,6 +65,7 @@ void IPSClock::loop() {
     
     unsigned long nowMs = millis();
 
+    // display refresh
     if (displayTimer.expired(nowMs)) {
         struct tm now;
         suseconds_t uSec;
@@ -84,7 +85,46 @@ void IPSClock::loop() {
             tfts->enableAllDisplays();
             // tfts->invalidateAllDigits();
 
-            if (getTimeOrDate().value == 0) {
+            // Display custom data if available: 
+            uint8_t customDataLength = getCustomData().value.length();
+            if (customDataLength > 0) {
+                for (uint8_t i = 0; i < NUM_DIGITS; i++) {
+                    char name[10];
+                    // no letter found for this digit -> use space
+                    if (i >= customDataLength) {
+                        strcpy(name, "space");
+                    }
+                    else 
+                    {
+                        char value = getCustomData().value[i];
+                        if (value == '_' or value == ' ') {
+                            strcpy(name, "space");
+                        } else if (value == ':') {
+                            strcpy(name, "colon");
+                        } else if (value == '0' || value == '1' || value == '2' || value == '3' || value == '4' || 
+                                   value == '5' || value == '6' || value == '7' || value == '8' || value == '9') {
+                            name[0] = value;
+                            name[1] = 0;
+                        } 
+                        // not a digit colon or space -> show as space
+                        else {
+                            strcpy(name, "space");
+                        }
+
+                    }
+                    uint8_t DIGITS[NUM_DIGITS] = {
+                        HOURS_TENS,
+                        HOURS_ONES,
+                        MINUTES_TENS,
+                        MINUTES_ONES,
+                        SECONDS_TENS,
+                        SECONDS_ONES
+                    };
+                    tfts->setDigit(DIGITS[i], name, TFTs::yes);
+                }
+            }
+            // Display time: 
+            else if (getTimeOrDate().value == 0) {
                 uint8_t hour = now.tm_hour;
 
                 // refresh starting on seconds
@@ -125,7 +165,9 @@ void IPSClock::loop() {
                 } else {
                     tfts->setDigit(HOURS_TENS, digitToName[hour / 10], TFTs::yes);
                 }
-            } else if (getTimeOrDate().value == 1) {
+            } 
+            // Display Date: 
+            else if (getTimeOrDate().value == 1) {
                 uint8_t day = now.tm_mday;
                 uint8_t month = now.tm_mon;
                 uint8_t year = now.tm_year;

--- a/src/IPSClock.h
+++ b/src/IPSClock.h
@@ -22,6 +22,7 @@ public:
     static StringConfigItem& getTimeZone() { static StringConfigItem time_zone("time_zone", 63, "EST5EDT,M3.2.0,M11.1.0"); return time_zone; }	// POSIX timezone format
     static IntConfigItem& getDimming() { static IntConfigItem dimming("dimming", 2); return dimming; }
     static ByteConfigItem& getBrightnessConfig() { static ByteConfigItem brightness_config("brightness_config", 255); return brightness_config; }
+    static StringConfigItem& getCustomData() { static StringConfigItem custom_data("custom_data", 10, ""); return custom_data; }	// Custom data for MQTT
 
     void init();
     void loop();

--- a/src/mqttBroker.cpp
+++ b/src/mqttBroker.cpp
@@ -60,6 +60,22 @@ void MQTTBroker::onMessage(char* topic, char* payload, AsyncMqttClientMessagePro
         } else if (strcmp(topic, brightnessTopic) == 0) {
             IPSClock::getBrightnessConfig() = atoi((const char*)mqttMessageBuffer);
             publishState();
+        } else if (strcmp(topic, customDataTopic) == 0) {
+            // TODO: get the max data from somewhere
+            if (length <= 6){
+                // empty string or clear/CLEAR will clear the custom data
+                if (strcmp((const char*)mqttMessageBuffer, "CLEAR") == 0
+                    || strcmp((const char*)mqttMessageBuffer, "clear") == 0){
+                    IPSClock::getCustomData() = "";
+                }
+                else{
+                    IPSClock::getCustomData() = (const char*)mqttMessageBuffer;
+                }
+                publishState();
+            }
+            else{
+                Serial.println("Custom data too long, ignoring");
+            }
         } else {
             Serial.print("Unknown topic: ");
             Serial.print(topic);
@@ -80,6 +96,7 @@ bool MQTTBroker::init(const String& id) {
         sprintf(persistentStateTopic, "clock/%s/persistent/state", id.c_str());
         sprintf(screenSaverTopic, "clock/%s/screen_saver/set", id.c_str());
         sprintf(brightnessTopic, "clock/%s/brightness/set", id.c_str());
+        sprintf(customDataTopic, "clock/%s/custom/set", id.c_str());
         sprintf(screenSaverDelayTopic, "clock/%s/screen_saver_delay/set", id.c_str());
 
         client.setServer(getHost().value.c_str(), getPort());
@@ -119,6 +136,7 @@ void MQTTBroker::publishState() {
             JsonDocument volatileState;
             volatileState["screen_saver_on"] = screenSaver->isOn() ? "ON" : "OFF";
             volatileState["brightness"] = IPSClock::getBrightnessConfig().value;
+            volatileState["custom"] = IPSClock::getCustomData().value;
             char buffer[256];
             size_t n = serializeJson(volatileState, buffer);
 
@@ -135,6 +153,7 @@ void MQTTBroker::sendHADiscoveryMessage() {
     client.subscribe(screenSaverTopic, 0);
     client.subscribe(screenSaverDelayTopic, 0);
     client.subscribe(brightnessTopic, 0);
+    client.subscribe(customDataTopic, 0);
 
     // This is the discovery topic for the 'screensaver' switch
     char discoveryTopic[128];
@@ -193,6 +212,28 @@ void MQTTBroker::sendHADiscoveryMessage() {
     doc["min"] = 10;
     doc["max"] = 255;
     doc["val_tpl"] = "{{ value_json.brightness }}";
+    doc["device"]["configuration_url"] = "http://" + WiFi.localIP().toString() + "/";
+    doc["device"]["name"] = manifest[3];
+    doc["device"]["identifiers"][0] = WiFi.macAddress();
+    doc["device"]["model"] = manifest[0];
+    doc["device"]["sw_version"] = manifest[1];
+
+    n = serializeJson(doc, buffer);
+
+    client.publish(discoveryTopic, 0, true, buffer, n);
+
+    sprintf(discoveryTopic, "homeassistant/text/%s/custom/config", id.c_str());
+
+    doc.clear();
+
+    doc["name"] = "Custom Data";
+    doc["icon"] = "mdi:clock-edit";
+    doc["unique_id"] = "custom-data" + id;
+    doc["stat_t"] = volatileStateTopic;
+    doc["cmd_t"] = customDataTopic;
+    doc["min"] = 0;
+    doc["max"] = 6;
+    doc["val_tpl"] = "{{ value_json.customData }}";
     doc["device"]["configuration_url"] = "http://" + WiFi.localIP().toString() + "/";
     doc["device"]["name"] = manifest[3];
     doc["device"]["identifiers"][0] = WiFi.macAddress();

--- a/src/mqttBroker.h
+++ b/src/mqttBroker.h
@@ -28,6 +28,7 @@ private:
     char volatileStateTopic[64];
     char screenSaverTopic[64];
     char brightnessTopic[64];
+    char customDataTopic[64];
     char screenSaverDelayTopic[64];
 
     bool reconnect = false;


### PR DESCRIPTION
I wanted to automate some things with my clock, e.g. showing a countdown. 

I added a custom text field in Homeassistant that allows to overwrite what the clock currently would show. 

E.g. you could write 9999 and it would overwrite to 9999. If you send clear or an empty string it will show the default clock again. 

After a restart the data is also cleared. 

Let me know if you have ideas for improvement. I tried to follow the concepts how it's currently implemented and adapt for my use case. 